### PR TITLE
Lightning Address List type implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ extern crate lnpbp;
 extern crate lazy_static;
 #[macro_use]
 extern crate internet2;
-#[macro_use]
 extern crate lightning_encoding;
 
 #[cfg(feature = "serde")]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1116,7 +1116,7 @@ impl LightningDecode for Messages {
     ) -> Result<Self, lightning_encoding::Error> {
         Ok((&*LNPWP_UNMARSHALLER
             .unmarshall(&Vec::<u8>::lightning_decode(d)?)
-            .map_err(|_err| {
+            .map_err(|_| {
                 lightning_encoding::Error::DataIntegrityError(s!(
                     "can't unmarshall LMP message"
                 ))

--- a/src/message.rs
+++ b/src/message.rs
@@ -26,7 +26,7 @@ use wallet::SECP256K1_PUBKEY_DUMB;
 use wallet::{HashLock, HashPreimage};
 
 use super::payment::{
-    Alias, ChannelId, NodeColor, ShortChannelId, TempChannelId,
+    AddressList, Alias, ChannelId, NodeColor, ShortChannelId, TempChannelId,
 };
 use crate::InitFeatures;
 
@@ -895,40 +895,6 @@ pub struct NodeAnnouncements {
 }
 
 #[derive(
-    Wrapper,
-    Clone,
-    Debug,
-    Display,
-    From,
-    PartialEq,
-    Eq,
-    LightningEncode,
-    LightningDecode,
-    StrictEncode,
-    StrictDecode,
-)]
-// TODO: Do manual lightning encoding implementations, since they must be
-//       encoded not as <bigsize> <array>, but as a u16 (little-endian!!! strict
-//       encoding uses big endian)
-#[display(Debug)] // TODO: Re-imlement display manually to format addrsses
-pub struct AddressList(Vec<AnnouncedNodeAddr>);
-
-#[derive(
-    Clone,
-    Debug,
-    From,
-    PartialEq,
-    Eq,
-    LightningEncode,
-    LightningDecode,
-    StrictEncode,
-    StrictDecode,
-)]
-// TODO: Impement sturcture data and encodings according to
-//       <https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#the-node_announcement-message>
-pub struct AnnouncedNodeAddr();
-
-#[derive(
     Clone,
     PartialEq,
     Eq,
@@ -1150,7 +1116,7 @@ impl LightningDecode for Messages {
     ) -> Result<Self, lightning_encoding::Error> {
         Ok((&*LNPWP_UNMARSHALLER
             .unmarshall(&Vec::<u8>::lightning_decode(d)?)
-            .map_err(|err| {
+            .map_err(|_err| {
                 lightning_encoding::Error::DataIntegrityError(s!(
                     "can't unmarshall LMP message"
                 ))

--- a/src/payment/extenders/htlc.rs
+++ b/src/payment/extenders/htlc.rs
@@ -149,7 +149,7 @@ impl Extension for Htlc {
                         .offered_htlcs
                         .iter()
                         .enumerate()
-                        .filter(|(_index, htlc)| htlc.id == message.htlc_id)
+                        .filter(|(_, htlc)| htlc.id == message.htlc_id)
                         .next()
                         .ok_or(channel::Error::HTLC(
                             "HTLC id didn't match".to_string(),
@@ -179,11 +179,11 @@ impl Extension for Htlc {
             Messages::UpdateFailHtlc(message) => {
                 if message.channel_id == self.channel_id {
                     // get the offered HTLC to fail
-                    let (index, _offered_htlc) = self
+                    let (index, _) = self
                         .offered_htlcs
                         .iter()
                         .enumerate()
-                        .filter(|(_index, htlc)| htlc.id == message.htlc_id)
+                        .filter(|(_, htlc)| htlc.id == message.htlc_id)
                         .next()
                         .ok_or(channel::Error::HTLC(
                             "HTLC id didn't match".to_string(),

--- a/src/payment/extenders/htlc.rs
+++ b/src/payment/extenders/htlc.rs
@@ -149,7 +149,7 @@ impl Extension for Htlc {
                         .offered_htlcs
                         .iter()
                         .enumerate()
-                        .filter(|(index, htlc)| htlc.id == message.htlc_id)
+                        .filter(|(_index, htlc)| htlc.id == message.htlc_id)
                         .next()
                         .ok_or(channel::Error::HTLC(
                             "HTLC id didn't match".to_string(),
@@ -179,11 +179,11 @@ impl Extension for Htlc {
             Messages::UpdateFailHtlc(message) => {
                 if message.channel_id == self.channel_id {
                     // get the offered HTLC to fail
-                    let (index, offered_htlc) = self
+                    let (index, _offered_htlc) = self
                         .offered_htlcs
                         .iter()
                         .enumerate()
-                        .filter(|(index, htlc)| htlc.id == message.htlc_id)
+                        .filter(|(_index, htlc)| htlc.id == message.htlc_id)
                         .next()
                         .ok_or(channel::Error::HTLC(
                             "HTLC id didn't match".to_string(),

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -19,8 +19,8 @@ mod extenders;
 mod modifiers;
 
 pub use types::{
-    Alias, AssetsBalance, ChannelId, ExtensionId, Lifecycle, NodeColor,
-    ShortChannelId, TempChannelId, TxType,
+    AddressList, Alias, AnnouncedNodeAddr, AssetsBalance, ChannelId,
+    ExtensionId, Lifecycle, NodeColor, ShortChannelId, TempChannelId, TxType,
 };
 
 pub use constructors::{bolt3, eltoo, taproot, Bolt3};

--- a/src/payment/types.rs
+++ b/src/payment/types.rs
@@ -481,14 +481,14 @@ impl lightning_encoding::Strategy for ShortChannelId {
 #[derive(Clone, Debug, From, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
 pub enum AnnouncedNodeAddr {
     /// An IPv4 address/port on which the peer is listening.
-    IPV4 {
+    IpV4 {
         /// The 4-byte IPv4 address
         addr: [u8; 4],
         /// The port on which the node is listening
         port: u16,
     },
     /// An IPv6 address/port on which the peer is listening.
-    IPV6 {
+    IpV6 {
         /// The 16-byte IPv6 address
         addr: [u8; 16],
         /// The port on which the node is listening
@@ -521,8 +521,8 @@ pub enum AnnouncedNodeAddr {
 impl AnnouncedNodeAddr {
     fn into_u8(&self) -> u8 {
         match self {
-            &AnnouncedNodeAddr::IPV4 { .. } => 1,
-            &AnnouncedNodeAddr::IPV6 { .. } => 2,
+            &AnnouncedNodeAddr::IpV4 { .. } => 1,
+            &AnnouncedNodeAddr::IpV6 { .. } => 2,
             &AnnouncedNodeAddr::OnionV2 { .. } => 3,
             &AnnouncedNodeAddr::OnionV3 { .. } => 4,
         }
@@ -532,8 +532,8 @@ impl AnnouncedNodeAddr {
 impl Uniform for AnnouncedNodeAddr {
     fn addr_format(&self) -> AddrFormat {
         match self {
-            AnnouncedNodeAddr::IPV4 { .. } => AddrFormat::IpV4,
-            AnnouncedNodeAddr::IPV6 { .. } => AddrFormat::IpV6,
+            AnnouncedNodeAddr::IpV4 { .. } => AddrFormat::IpV4,
+            AnnouncedNodeAddr::IpV6 { .. } => AddrFormat::IpV6,
             AnnouncedNodeAddr::OnionV2 { .. } => AddrFormat::OnionV2,
             AnnouncedNodeAddr::OnionV3 { .. } => AddrFormat::OnionV3,
         }
@@ -541,13 +541,13 @@ impl Uniform for AnnouncedNodeAddr {
 
     fn addr(&self) -> RawAddr {
         match self {
-            AnnouncedNodeAddr::IPV4 { addr, .. } => {
+            AnnouncedNodeAddr::IpV4 { addr, .. } => {
                 let mut ip = [0u8; ADDR_LEN];
                 ip[29..].copy_from_slice(addr);
                 ip
             }
 
-            AnnouncedNodeAddr::IPV6 { addr, .. } => {
+            AnnouncedNodeAddr::IpV6 { addr, .. } => {
                 let mut ip = [0u8; ADDR_LEN];
                 ip[17..].copy_from_slice(addr);
                 ip
@@ -570,8 +570,8 @@ impl Uniform for AnnouncedNodeAddr {
     fn port(&self) -> Option<u16> {
         match self {
             // How to remove these unused variables?
-            AnnouncedNodeAddr::IPV4 { port, .. } => Some(port.clone()),
-            AnnouncedNodeAddr::IPV6 { port, .. } => Some(port.clone()),
+            AnnouncedNodeAddr::IpV4 { port, .. } => Some(port.clone()),
+            AnnouncedNodeAddr::IpV6 { port, .. } => Some(port.clone()),
             AnnouncedNodeAddr::OnionV2 { port, .. } => Some(port.clone()),
             AnnouncedNodeAddr::OnionV3 { port, .. } => Some(port.clone()),
         }
@@ -590,7 +590,7 @@ impl Uniform for AnnouncedNodeAddr {
             AddrFormat::IpV4 => {
                 let mut ip = [0u8; 4];
                 ip.copy_from_slice(&addr.addr[29..]);
-                Ok(AnnouncedNodeAddr::IPV4 {
+                Ok(AnnouncedNodeAddr::IpV4 {
                     addr: ip,
                     port: match addr.port {
                         Some(p) => p,
@@ -602,7 +602,7 @@ impl Uniform for AnnouncedNodeAddr {
             AddrFormat::IpV6 => {
                 let mut ip = [0u8; 16];
                 ip.copy_from_slice(&addr.addr[17..]);
-                Ok(AnnouncedNodeAddr::IPV6 {
+                Ok(AnnouncedNodeAddr::IpV6 {
                     addr: ip,
                     port: match addr.port {
                         Some(p) => p,
@@ -659,13 +659,13 @@ impl StrictEncode for AnnouncedNodeAddr {
         let mut len = 0;
 
         match self {
-            AnnouncedNodeAddr::IPV4 { addr, port } => {
+            AnnouncedNodeAddr::IpV4 { addr, port } => {
                 len += e.write(&self.into_u8().to_be_bytes()[..])?;
                 len += e.write(&addr[..])?;
                 len += e.write(&port.to_be_bytes()[..])?;
                 Ok(len)
             }
-            AnnouncedNodeAddr::IPV6 { addr, port } => {
+            AnnouncedNodeAddr::IpV6 { addr, port } => {
                 let mut len = 0;
                 len += e.write(&self.into_u8().to_be_bytes()[..])?;
                 len += e.write(&addr[..])?;
@@ -729,7 +729,7 @@ impl StrictDecode for AnnouncedNodeAddr {
                 d.read_exact(&mut port[..])?;
                 let port = u16::from_be_bytes(port);
 
-                Ok(AnnouncedNodeAddr::IPV4 {
+                Ok(AnnouncedNodeAddr::IpV4 {
                     addr: addr,
                     port: port,
                 })
@@ -742,7 +742,7 @@ impl StrictDecode for AnnouncedNodeAddr {
                 d.read_exact(&mut port[..])?;
                 let port = u16::from_be_bytes(port);
 
-                Ok(AnnouncedNodeAddr::IPV6 {
+                Ok(AnnouncedNodeAddr::IpV6 {
                     addr: addr,
                     port: port,
                 })
@@ -842,12 +842,12 @@ mod test {
     #[test]
     fn test_address_encodings() {
         // Test vectors taken from https://github.com/rust-bitcoin/rust-lightning/blob/main/lightning/src/ln/msgs.rs
-        let ipv4 = AnnouncedNodeAddr::IPV4 {
+        let ipv4 = AnnouncedNodeAddr::IpV4 {
             addr: [255, 254, 253, 252],
             port: 9735,
         };
 
-        let ipv6 = AnnouncedNodeAddr::IPV6 {
+        let ipv6 = AnnouncedNodeAddr::IpV6 {
             addr: [
                 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244,
                 243, 242, 241, 240,

--- a/src/payment/types.rs
+++ b/src/payment/types.rs
@@ -23,6 +23,9 @@ use bitcoin::hashes::hex::{Error, FromHex};
 use bitcoin::hashes::Hash;
 use bitcoin::OutPoint;
 use lnpbp::chain::AssetId;
+use strict_encoding::net::{
+    AddrFormat, DecodeError, RawAddr, Transport, Uniform, UniformAddr, ADDR_LEN,
+};
 use strict_encoding::{
     self, strict_deserialize, strict_serialize, StrictDecode, StrictEncode,
 };
@@ -473,4 +476,476 @@ impl StrictDecode for ShortChannelId {
 
 impl lightning_encoding::Strategy for ShortChannelId {
     type Strategy = lightning_encoding::strategies::AsStrict;
+}
+
+#[derive(Clone, Debug, From, PartialEq, Eq)]
+pub enum AnnouncedNodeAddr {
+    /// An IPv4 address/port on which the peer is listening.
+    IPv4 {
+        /// The 4-byte IPv4 address
+        addr: [u8; 4],
+        /// The port on which the node is listening
+        port: u16,
+    },
+    /// An IPv6 address/port on which the peer is listening.
+    IPv6 {
+        /// The 16-byte IPv6 address
+        addr: [u8; 16],
+        /// The port on which the node is listening
+        port: u16,
+    },
+    /// An old-style Tor onion address/port on which the peer is listening.
+    OnionV2 {
+        /// The bytes (usually encoded in base32 with ".onion" appended)
+        addr: [u8; 10],
+        /// The port on which the node is listening
+        port: u16,
+    },
+    /// A new-style Tor onion address/port on which the peer is listening.
+    /// To create the human-readable "hostname", concatenate ed25519_pubkey,
+    /// checksum, and version, wrap as base32 and append ".onion".
+    OnionV3 {
+        /// The ed25519 long-term public key of the peer
+        ed25519_pubkey: [u8; 32],
+        /// The checksum of the pubkey and version, as included in the onion
+        /// address
+        // Optional values taken here to be compatible with Uniform encoding
+        checksum: Option<u16>,
+        /// The version byte, as defined by the Tor Onion v3 spec.
+        version: Option<u8>,
+        /// The port on which the node is listening
+        port: u16,
+    },
+}
+
+impl AnnouncedNodeAddr {
+    fn get_id(&self) -> u8 {
+        match self {
+            &AnnouncedNodeAddr::IPv4 { .. } => 1,
+            &AnnouncedNodeAddr::IPv6 { .. } => 2,
+            &AnnouncedNodeAddr::OnionV2 { .. } => 3,
+            &AnnouncedNodeAddr::OnionV3 { .. } => 4,
+        }
+    }
+}
+
+impl Uniform for AnnouncedNodeAddr {
+    fn addr_format(&self) -> AddrFormat {
+        match self {
+            AnnouncedNodeAddr::IPv4 { .. } => AddrFormat::IpV4,
+            AnnouncedNodeAddr::IPv6 { .. } => AddrFormat::IpV6,
+            AnnouncedNodeAddr::OnionV2 { .. } => AddrFormat::OnionV2,
+            AnnouncedNodeAddr::OnionV3 { .. } => AddrFormat::OnionV3,
+        }
+    }
+
+    fn addr(&self) -> RawAddr {
+        match self {
+            AnnouncedNodeAddr::IPv4 { addr, .. } => {
+                let mut ip = [0u8; ADDR_LEN];
+                ip[29..].copy_from_slice(addr);
+                ip
+            }
+
+            AnnouncedNodeAddr::IPv6 { addr, .. } => {
+                let mut ip = [0u8; ADDR_LEN];
+                ip[17..].copy_from_slice(addr);
+                ip
+            }
+
+            AnnouncedNodeAddr::OnionV2 { addr, .. } => {
+                let mut ip = [0u8; ADDR_LEN];
+                ip[23..].copy_from_slice(addr);
+                ip
+            }
+
+            AnnouncedNodeAddr::OnionV3 { ed25519_pubkey, .. } => {
+                let mut ip = [0u8; ADDR_LEN];
+                ip[1..].copy_from_slice(ed25519_pubkey);
+                ip
+            }
+        }
+    }
+
+    fn port(&self) -> Option<u16> {
+        match self {
+            // How to remove these unused variables?
+            AnnouncedNodeAddr::IPv4 { addr: _, port } => Some(port.clone()),
+            AnnouncedNodeAddr::IPv6 { addr: _, port } => Some(port.clone()),
+            AnnouncedNodeAddr::OnionV2 { addr: _, port } => Some(port.clone()),
+            AnnouncedNodeAddr::OnionV3 {
+                ed25519_pubkey: _,
+                checksum: _,
+                version: _,
+                port,
+            } => Some(port.clone()),
+        }
+    }
+
+    #[inline]
+    fn transport(&self) -> Option<Transport> {
+        None
+    }
+
+    fn from_uniform_addr_lossy(addr: UniformAddr) -> Result<Self, DecodeError>
+    where
+        Self: Sized,
+    {
+        match addr.addr_format() {
+            AddrFormat::IpV4 => {
+                let mut ip = [0u8; 4];
+                ip.copy_from_slice(&addr.addr[29..]);
+                Ok(AnnouncedNodeAddr::IPv4 {
+                    addr: ip,
+                    port: match addr.port {
+                        Some(p) => p,
+                        _ => return Err(DecodeError::InsufficientData),
+                    },
+                })
+            }
+
+            AddrFormat::IpV6 => {
+                let mut ip = [0u8; 16];
+                ip.copy_from_slice(&addr.addr[17..]);
+                Ok(AnnouncedNodeAddr::IPv6 {
+                    addr: ip,
+                    port: match addr.port {
+                        Some(p) => p,
+                        _ => return Err(DecodeError::InsufficientData),
+                    },
+                })
+            }
+
+            AddrFormat::OnionV2 => {
+                let mut ip = [0u8; 10];
+                ip.copy_from_slice(&addr.addr[23..]);
+                Ok(AnnouncedNodeAddr::OnionV2 {
+                    addr: ip,
+                    port: match addr.port {
+                        Some(p) => p,
+                        _ => return Err(DecodeError::InsufficientData),
+                    },
+                })
+            }
+
+            AddrFormat::OnionV3 => {
+                let mut ip = [0u8; 32];
+                ip.copy_from_slice(&addr.addr[1..]);
+                Ok(AnnouncedNodeAddr::OnionV3 {
+                    ed25519_pubkey: ip,
+                    // Converting from Uniform encoding will always lead these
+                    // values to be None
+                    checksum: None,
+                    version: None,
+                    port: match addr.port {
+                        Some(p) => p,
+                        _ => return Err(DecodeError::InsufficientData),
+                    },
+                })
+            }
+
+            _ => Err(DecodeError::InvalidAddr),
+        }
+    }
+
+    fn from_uniform_addr(addr: UniformAddr) -> Result<Self, DecodeError>
+    where
+        Self: Sized,
+    {
+        AnnouncedNodeAddr::from_uniform_addr_lossy(addr)
+    }
+}
+
+impl StrictEncode for AnnouncedNodeAddr {
+    fn strict_encode<E: io::Write>(
+        &self,
+        mut e: E,
+    ) -> Result<usize, strict_encoding::Error> {
+        let mut len = 0;
+
+        match self {
+            AnnouncedNodeAddr::IPv4 { addr, port } => {
+                len += e.write(&self.get_id().to_be_bytes()[..])?;
+                len += e.write(&addr[..])?;
+                len += e.write(&port.to_be_bytes()[..])?;
+                Ok(len)
+            }
+            AnnouncedNodeAddr::IPv6 { addr, port } => {
+                let mut len = 0;
+                len += e.write(&self.get_id().to_be_bytes()[..])?;
+                len += e.write(&addr[..])?;
+                len += e.write(&port.to_be_bytes()[..])?;
+
+                Ok(len)
+            }
+            AnnouncedNodeAddr::OnionV2 { addr, port } => {
+                let mut len = 0;
+                len += e.write(&self.get_id().to_be_bytes()[..])?;
+                len += e.write(&addr[..])?;
+                len += e.write(&port.to_be_bytes()[..])?;
+
+                Ok(len)
+            }
+
+            AnnouncedNodeAddr::OnionV3 {
+                ed25519_pubkey,
+                checksum,
+                version,
+                port,
+            } => {
+                let mut len = 0;
+                len += e.write(&self.get_id().to_be_bytes()[..])?;
+                len += e.write(&ed25519_pubkey[..])?;
+                if let Some(checksum) = checksum {
+                    len += e.write(&checksum.to_be_bytes()[..])?;
+                } else {
+                    return Err(strict_encoding::Error::DataIntegrityError(
+                        "checksum value must be present".to_string(),
+                    ));
+                };
+                if let Some(version) = version {
+                    len += e.write(&version.to_be_bytes()[..])?;
+                } else {
+                    return Err(strict_encoding::Error::DataIntegrityError(
+                        "version value must be present".to_string(),
+                    ));
+                }
+                len += e.write(&port.to_be_bytes()[..])?;
+
+                Ok(len)
+            }
+        }
+    }
+}
+
+impl StrictDecode for AnnouncedNodeAddr {
+    fn strict_decode<D: io::Read>(
+        mut d: D,
+    ) -> Result<Self, strict_encoding::Error> {
+        let mut type_byte = [0u8; 1];
+        d.read_exact(&mut type_byte)?;
+        let type_byte = u8::from_be_bytes(type_byte);
+
+        match type_byte {
+            1u8 => {
+                let mut addr = [0u8; 4];
+                let mut port = [0u8; 2];
+                d.read_exact(&mut addr[..])?;
+                d.read_exact(&mut port[..])?;
+                let port = u16::from_be_bytes(port);
+
+                Ok(AnnouncedNodeAddr::IPv4 {
+                    addr: addr,
+                    port: port,
+                })
+            }
+
+            2u8 => {
+                let mut addr = [0u8; 16];
+                let mut port = [0u8; 2];
+                d.read_exact(&mut addr[..])?;
+                d.read_exact(&mut port[..])?;
+                let port = u16::from_be_bytes(port);
+
+                Ok(AnnouncedNodeAddr::IPv6 {
+                    addr: addr,
+                    port: port,
+                })
+            }
+
+            3u8 => {
+                let mut addr = [0u8; 10];
+                let mut port = [0u8; 2];
+                d.read_exact(&mut addr[..])?;
+                d.read_exact(&mut port[..])?;
+                let port = u16::from_be_bytes(port);
+
+                Ok(AnnouncedNodeAddr::OnionV2 {
+                    addr: addr,
+                    port: port,
+                })
+            }
+
+            4u8 => {
+                let mut ed2559_pubkey = [0u8; 32];
+                let mut checksum = [0u8; 2];
+                let mut version = [0u8; 1];
+                let mut port = [0u8; 2];
+                d.read_exact(&mut ed2559_pubkey[..])?;
+                d.read_exact(&mut checksum[..])?;
+                d.read_exact(&mut version[..])?;
+                d.read_exact(&mut port[..])?;
+                let checksum = u16::from_be_bytes(checksum);
+                let version = u8::from_be_bytes(version);
+                let port = u16::from_be_bytes(port);
+
+                Ok(AnnouncedNodeAddr::OnionV3 {
+                    ed25519_pubkey: ed2559_pubkey,
+                    checksum: Some(checksum),
+                    version: Some(version),
+                    port: port,
+                })
+            }
+
+            _ => Err(strict_encoding::Error::UnsupportedDataStructure(
+                "Wrong Network Address Format",
+            )),
+        }
+    }
+}
+
+impl lightning_encoding::Strategy for AnnouncedNodeAddr {
+    type Strategy = lightning_encoding::strategies::AsStrict;
+}
+
+#[derive(Wrapper, Clone, Debug, Display, From, PartialEq, Eq)]
+#[display(Debug)]
+pub struct AddressList(Vec<AnnouncedNodeAddr>);
+
+impl StrictEncode for AddressList {
+    fn strict_encode<E: io::Write>(
+        &self,
+        mut e: E,
+    ) -> Result<usize, strict_encoding::Error> {
+        let mut written = 0;
+        let len = self.0.len() as u16;
+        written += e.write(&len.to_be_bytes()[..])?;
+        for addr in &self.0 {
+            written += addr.strict_encode(&mut e)?;
+        }
+        Ok(written)
+    }
+}
+
+impl StrictDecode for AddressList {
+    fn strict_decode<D: io::Read>(
+        mut d: D,
+    ) -> Result<Self, strict_encoding::Error> {
+        let mut len_bytes = [0u8; 2];
+        d.read_exact(&mut len_bytes)?;
+        let len = u16::from_be_bytes(len_bytes) as usize;
+        let mut data = Vec::<AnnouncedNodeAddr>::with_capacity(len);
+        for _ in 0..len {
+            data.push(AnnouncedNodeAddr::strict_decode(&mut d)?);
+        }
+        Ok(AddressList(data))
+    }
+}
+
+impl lightning_encoding::Strategy for AddressList {
+    type Strategy = lightning_encoding::strategies::AsStrict;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bitcoin::hashes::hex::FromHex;
+    use lightning_encoding::{LightningDecode, LightningEncode};
+
+    #[test]
+    fn test_address_encodings() {
+        // Test vectors taken from https://github.com/rust-bitcoin/rust-lightning/blob/main/lightning/src/ln/msgs.rs
+        let ipv4 = AnnouncedNodeAddr::IPv4 {
+            addr: [255, 254, 253, 252],
+            port: 9735,
+        };
+
+        let ipv6 = AnnouncedNodeAddr::IPv6 {
+            addr: [
+                255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244,
+                243, 242, 241, 240,
+            ],
+            port: 9735,
+        };
+
+        let onion_v2 = AnnouncedNodeAddr::OnionV2 {
+            addr: [255, 254, 253, 252, 251, 250, 249, 248, 247, 246],
+            port: 9735,
+        };
+
+        let onion_v3 = AnnouncedNodeAddr::OnionV3 {
+            ed25519_pubkey: [
+                255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244,
+                243, 242, 241, 240, 239, 238, 237, 236, 235, 234, 233, 232,
+                231, 230, 229, 228, 227, 226, 225, 224,
+            ],
+            checksum: Some(32),
+            version: Some(16),
+            port: 9735,
+        };
+
+        let ipv4_target = Vec::<u8>::from_hex("01fffefdfc2607").unwrap();
+        let ipv6_target =
+            Vec::<u8>::from_hex("02fffefdfcfbfaf9f8f7f6f5f4f3f2f1f02607")
+                .unwrap();
+        let onionv2_target =
+            Vec::<u8>::from_hex("03fffefdfcfbfaf9f8f7f62607").unwrap();
+        let onionv3_target = Vec::<u8>::from_hex("04fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0efeeedecebeae9e8e7e6e5e4e3e2e1e00020102607").unwrap();
+
+        // Check strict encoding/decoding
+        let ipv4_encoded = ipv4.lightning_serialize();
+        let ipv6_encoded = ipv6.lightning_serialize();
+        let onionv2_encoded = onion_v2.lightning_serialize();
+        let onionv3_encoded = onion_v3.lightning_serialize();
+
+        let ipv4_decoded =
+            AnnouncedNodeAddr::lightning_deserialize(&ipv4_target).unwrap();
+        let ipv6_decoded =
+            AnnouncedNodeAddr::lightning_deserialize(&ipv6_target).unwrap();
+        let onionv2_decoded =
+            AnnouncedNodeAddr::lightning_deserialize(&onionv2_target).unwrap();
+        let onionv3_decoded =
+            AnnouncedNodeAddr::lightning_deserialize(&onionv3_target).unwrap();
+
+        assert_eq!(ipv4, ipv4_decoded);
+        assert_eq!(ipv6, ipv6_decoded);
+        assert_eq!(onion_v2, onionv2_decoded);
+        assert_eq!(onion_v3, onionv3_decoded);
+
+        assert_eq!(ipv4_encoded, ipv4_target);
+        assert_eq!(ipv6_encoded, ipv6_target);
+        assert_eq!(onionv2_encoded, onionv2_target);
+        assert_eq!(onionv3_encoded, onionv3_target);
+
+        // Check Uniform encoding/decoding
+        let uniform_ipv4 = ipv4.to_uniform_addr();
+        let uniform_ipv6 = ipv6.to_uniform_addr();
+        let uniform_onionv2 = onion_v2.to_uniform_addr();
+        let uniform_onionv3 = onion_v3.to_uniform_addr();
+
+        let uniform_ipv4_decoded =
+            AnnouncedNodeAddr::from_uniform_addr(uniform_ipv4).unwrap();
+        let uniform_ipv6_decoded =
+            AnnouncedNodeAddr::from_uniform_addr(uniform_ipv6).unwrap();
+        let uniform_onionv2_decoded =
+            AnnouncedNodeAddr::from_uniform_addr(uniform_onionv2).unwrap();
+        let uniform_onionv3_decoded =
+            AnnouncedNodeAddr::from_uniform_addr(uniform_onionv3).unwrap();
+
+        // IPV4, IPV6 and OnionV2 should match
+        assert_eq!(ipv4, uniform_ipv4_decoded);
+        assert_eq!(ipv6, uniform_ipv6_decoded);
+        assert_eq!(onion_v2, uniform_onionv2_decoded);
+
+        // OnionV3 will have None as checksum and version
+        let uniform_v3_target = AnnouncedNodeAddr::OnionV3 {
+            ed25519_pubkey: [
+                255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244,
+                243, 242, 241, 240, 239, 238, 237, 236, 235, 234, 233, 232,
+                231, 230, 229, 228, 227, 226, 225, 224,
+            ],
+            checksum: None,
+            version: None,
+            port: 9735,
+        };
+        assert_eq!(uniform_v3_target, uniform_onionv3_decoded);
+
+        // AddressList encoding/decoding
+        let address_list = AddressList(vec![ipv4, ipv6, onion_v2, onion_v3]);
+        let address_list_target = Vec::<u8>::from_hex("000401fffefdfc260702fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0260703fffefdfcfbfaf9f8f7f6260704fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0efeeedecebeae9e8e7e6e5e4e3e2e1e00020102607").unwrap();
+
+        let address_list_encoded = address_list.lightning_serialize();
+
+        assert_eq!(address_list_encoded, address_list_target)
+    }
 }


### PR DESCRIPTION
This implements Lightning address list types as per https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#the-node_announcement-message.

Strict, Lightning, and Uniform encoding is derived using Big Endian order. `AddressList` encoding starts with `u16`.

Added relevant tests.  