### PR TITLE
fix build

### DIFF
--- a/lnp2p/Cargo.toml
+++ b/lnp2p/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.12.0"
 chrono = "0.4"
 
 [features]
-default = ["bolt"]
+default = ["bifrost", "bolt"]
 all = ['bifrost', "serde"]
 bolt = ["lightning_encoding"]
 bifrost = ["strict_encoding"]


### PR DESCRIPTION
As reported in https://github.com/RGB-WG/rgb-node/pull/224#issuecomment-1356790028 documentation of lnp-core doesn't build on docs.rs (https://docs.rs/crate/lnp-core/0.8.0/builds/592909).

Cloning the repository locally and running `cargo build` produces the same error logs we see on docs.rs. Adding `bifrost` to the default features of lnp2p seems to fix the build.

@dr-orlovsky if you think this fix is appropriate then you can release this first and rgb-node after. Thank you