### PR TITLE
feat: add codespell lint job into workflows & fix typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,3 +55,10 @@ jobs:
         with:
           command: doc
           args: --workspace --all-features
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: crate-ci/typos@master
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ v0.2.0-beta.3
 - Multiple BIP-32 improvements on top of rust-bitcoin functionality
 - Better CI
 - Android/iOS/Windows/MacOs build fixes
-- AchorId strict encoding
+- AnchorId strict encoding
 - Fixed issue with broken `serde_with` macro (pinned older version in Cargo.toml)
 - More collection types supporting `AutoConceal`
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Don't correct the name "Jon Atack".
+Atack = "Atack"
+optin = "optin"

--- a/lnp2p/src/bifrost/channel.rs
+++ b/lnp2p/src/bifrost/channel.rs
@@ -31,7 +31,7 @@ pub enum CommonFeeAlgo {
     /// Common fees are paid by the channel coordinator
     ByCoordinator,
 
-    /// Common fees are paid in proportional amounts by all participats
+    /// Common fees are paid in proportional amounts by all participants
     SharedFee,
 }
 
@@ -209,7 +209,7 @@ pub struct UpgradeChannel {
 
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Display)]
 #[derive(NetworkEncode, NetworkDecode)]
-#[display("donwgrade_channel({channel_id}, {protocol}, ...)")]
+#[display("downgrade_channel({channel_id}, {protocol}, ...)")]
 pub struct DowngradeChannel {
     pub channel_id: ChannelId,
     pub protocol: ProtocolName,

--- a/lnp2p/src/bifrost/ctrl.rs
+++ b/lnp2p/src/bifrost/ctrl.rs
@@ -52,7 +52,7 @@ pub struct Error {
     pub channel_id: Option<ChannelId>,
     pub errno: u64,
     pub message: Option<String>,
-    /// Any additiona error details
+    /// Any additional error details
     #[network_encoding(unknown_tlvs)]
     pub unknown_tlvs: tlv::Stream,
 }

--- a/lnp2p/src/bifrost/proposals.rs
+++ b/lnp2p/src/bifrost/proposals.rs
@@ -84,7 +84,7 @@ pub struct ChannelInput {
     /// witness for the input. Always v0+ witness
     pub descriptor: SegwitDescriptor,
 
-    /// Witness satisfying prevous transaction descriptor.
+    /// Witness satisfying previous transaction descriptor.
     ///
     /// Must be present only when the transaction is signed
     pub witness: Option<Witness>,
@@ -152,7 +152,7 @@ pub enum ChannelFunding {
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 #[derive(NetworkEncode, NetworkDecode)]
 pub struct ChannelLink {
-    /// Amount allocated to the transaction outut and consumed by the child
+    /// Amount allocated to the transaction output and consumed by the child
     /// channel transaction
     pub amount: Amount,
 
@@ -163,7 +163,7 @@ pub struct ChannelLink {
     ///
     /// We provide full descriptor to enable nodes to use custom keys. Still,
     /// the descriptor mod key values MUST match template defined for the
-    /// gived [`TxRole`] from [`ChannelTx::children`] containing this link.
+    /// given [`TxRole`] from [`ChannelTx::children`] containing this link.
     pub descriptor: TaprootDescriptor,
 
     /// Sequence number to use in the child transaction input

--- a/lnp2p/src/bolt/bolt2.rs
+++ b/lnp2p/src/bolt/bolt2.rs
@@ -562,7 +562,7 @@ pub struct UpdateAddHtlc {
 #[derive(Clone, PartialEq, Eq, Debug, Display)]
 #[derive(LightningEncode, LightningDecode)]
 #[cfg_attr(feature = "strict_encoding", derive(NetworkEncode, NetworkDecode))]
-#[display("update_fullfill_htlc({channel_id}, {htlc_id}, ...preimages)")]
+#[display("update_fulfill_htlc({channel_id}, {htlc_id}, ...preimages)")]
 pub struct UpdateFulfillHtlc {
     /// The channel ID
     pub channel_id: ChannelId,

--- a/lnp2p/src/bolt/bolt7.rs
+++ b/lnp2p/src/bolt/bolt7.rs
@@ -198,7 +198,7 @@ pub struct ReplyShortChannelIdsEnd {
 #[derive(LightningEncode, LightningDecode)]
 #[cfg_attr(feature = "strict_encoding", derive(NetworkEncode, NetworkDecode))]
 #[display(
-    "querry_channel_range({chain_hash}, {first_blocknum}, {number_of_blocks}, \
+    "query_channel_range({chain_hash}, {first_blocknum}, {number_of_blocks}, \
      ...tlvs)"
 )]
 pub struct QueryChannelRange {

--- a/lnp2p/src/bolt/types.rs
+++ b/lnp2p/src/bolt/types.rs
@@ -360,7 +360,7 @@ pub enum ShortChannelIdParseError {
     WrongOutputIndex,
     /// too many short channel id components; expected three (block height,
     /// tx index and output index)
-    ExessiveComponents,
+    ExcessiveComponents,
 }
 
 impl FromStr for ShortChannelId {
@@ -382,7 +382,7 @@ impl FromStr for ShortChannelId {
                     })?,
                 })
             }
-            _ => Err(ShortChannelIdParseError::ExessiveComponents),
+            _ => Err(ShortChannelIdParseError::ExcessiveComponents),
         }
     }
 }

--- a/src/channel/bolt/channel.rs
+++ b/src/channel/bolt/channel.rs
@@ -85,10 +85,10 @@ pub enum Error {
     },
 
     /// the channel does not have permanent channel_id assigned
-    NoChanelId,
+    NoChannelId,
 
     /// the channel must have a temporary channel id and not be active for the
-    /// operaiton
+    /// operation
     NoTemporaryId,
 }
 
@@ -187,7 +187,7 @@ impl Channel<BoltExt> {
         self.constructor_mut().set_policy(policy)
     }
 
-    /// Sets common parameters for the chanel.
+    /// Sets common parameters for the channel.
     ///
     /// Can be used for changing prospective channel parameters on the fly to
     /// enable accepting new `open_channel` - or follow-up `accept_channel`
@@ -223,7 +223,7 @@ impl Channel<BoltExt> {
     /// otherwise.
     #[inline]
     pub fn try_channel_id(&self) -> Result<ChannelId, Error> {
-        self.channel_id().ok_or(Error::NoChanelId)
+        self.channel_id().ok_or(Error::NoChannelId)
     }
 
     /// Before the channel is assigned a final [`ChannelId`] returns
@@ -498,7 +498,7 @@ impl BoltChannel {
     /// otherwise.
     #[inline]
     pub fn try_channel_id(&self) -> Result<ChannelId, Error> {
-        self.channel_id().ok_or(Error::NoChanelId)
+        self.channel_id().ok_or(Error::NoChannelId)
     }
 
     /// Assigns channel a temporary id
@@ -531,7 +531,7 @@ impl BoltChannel {
         self.policy = policy
     }
 
-    /// Sets common parameters for the chanel
+    /// Sets common parameters for the channel
     #[inline]
     pub fn set_common_params(&mut self, params: CommonParams) {
         self.common_params = params

--- a/src/channel/bolt/extensions/htlc.rs
+++ b/src/channel/bolt/extensions/htlc.rs
@@ -64,7 +64,7 @@ pub struct Htlc {
     /// will be pushed through an anchor transaction.
     anchors_zero_fee_htlc_tx: bool,
 
-    // Sets of HTLC informations
+    // Sets of HTLC information
     offered_htlcs: BTreeMap<u64, HtlcSecret>,
     received_htlcs: BTreeMap<u64, HtlcSecret>,
     resolved_htlcs: BTreeMap<u64, HtlcKnown>,

--- a/src/channel/bolt/keyset.rs
+++ b/src/channel/bolt/keyset.rs
@@ -204,7 +204,7 @@ impl LocalKeyset {
         channel_xpriv: ExtendedPrivKey,
         shutdown_scriptpubkey: Option<PubkeyScript>,
     ) -> Self {
-        let fingerpint = channel_source.0;
+        let fingerprint = channel_source.0;
 
         let secrets = (0u16..=6)
             .into_iter()
@@ -232,7 +232,7 @@ impl LocalKeyset {
                     .private_key;
                 LocalPubkey {
                     key: PublicKey::from_secret_key(secp, &seckey),
-                    source: (fingerpint, derivation_path),
+                    source: (fingerprint, derivation_path),
                 }
             })
             .collect::<Vec<_>>();

--- a/src/channel/bolt/policy.rs
+++ b/src/channel/bolt/policy.rs
@@ -482,7 +482,7 @@ impl Policy {
 }
 
 /// Structure containing part of the channel configuration (and state, as it
-/// contains adjustible fee) which must follow specific policies and be accepted
+/// contains adjustable fee) which must follow specific policies and be accepted
 /// or validated basing on those policies and additional protocol-level
 /// requirements.
 ///
@@ -930,7 +930,7 @@ mod test {
     }
 
     #[test]
-    fn test_local_dust_limit_exeeds_remote_reserve() {
+    fn test_local_dust_limit_exceeds_remote_reserve() {
         let policy = Policy::default();
         let open_channel = get_open_channel();
         let mut accept_channel = get_accept_channel();

--- a/src/channel/bolt/state.rs
+++ b/src/channel/bolt/state.rs
@@ -97,7 +97,7 @@ pub struct ChannelState {
     pub offered_htlcs: BTreeMap<u64, HtlcSecret>,
     pub received_htlcs: BTreeMap<u64, HtlcSecret>,
     pub resolved_htlcs: BTreeMap<u64, HtlcKnown>,
-    pub last_recieved_htlc_id: u64,
+    pub last_received_htlc_id: u64,
     pub last_offered_htlc_id: u64,
 }
 
@@ -139,7 +139,7 @@ impl DumbDefault for ChannelState {
             offered_htlcs: none!(),
             received_htlcs: none!(),
             resolved_htlcs: none!(),
-            last_recieved_htlc_id: 0,
+            last_received_htlc_id: 0,
             last_offered_htlc_id: 0,
         }
     }

--- a/src/channel/channel.rs
+++ b/src/channel/channel.rs
@@ -199,7 +199,7 @@ where
 
     /// Adds new extension to the channel.
     ///
-    /// Will be effective onl upon next channel state update.
+    /// Will be effective only upon next channel state update.
     #[inline]
     pub fn add_extender(&mut self, extension: Box<dyn ChannelExtension<N>>) {
         self.extenders.insert(extension.identity(), extension);
@@ -207,7 +207,7 @@ where
 
     /// Adds new modifier to the channel.
     ///
-    /// Will be effective onl upon next channel state update.
+    /// Will be effective only upon next channel state update.
     #[inline]
     pub fn add_modifier(&mut self, modifier: Box<dyn ChannelExtension<N>>) {
         self.modifiers.insert(modifier.identity(), modifier);


### PR DESCRIPTION
Closes #34 

1. feat: add codespell lint job into workflows
2. fix typos caught by lint job.

Please help me to review. Thank you very much.